### PR TITLE
return promise to upload object

### DIFF
--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -307,19 +307,19 @@ export class AWSS3Provider implements StorageProvider {
 				}
 			});
 
-			const response = await uploader.upload();
-
-			logger.debug('upload result', response);
-			dispatchStorageEvent(
-				track,
-				'upload',
-				{ method: 'put', result: 'success' },
-				null,
-				`Upload success for ${key}`
-			);
-			return {
-				key,
-			};
+			return uploader.upload().then(response => {
+				logger.debug('upload result', response);
+				dispatchStorageEvent(
+					track,
+					'upload',
+					{ method: 'put', result: 'success' },
+					null,
+					`Upload success for ${key}`
+				);
+				return {
+					key,
+				};
+			});
 		} catch (error) {
 			logger.warn('error uploading', error);
 			dispatchStorageEvent(


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Return a promise to upload the object instead of awaiting the promise to complete. Doing so should allow the upload request to be canceled.

References/Example: https://github.com/aws-amplify/amplify-js/pull/4558/files#

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
